### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/connect-integration-teleopti-wfm-workload.json
+++ b/templates/connect-integration-teleopti-wfm-workload.json
@@ -144,7 +144,7 @@
 					"Fn::GetAtt": ["TeleoptiIntegrationTestRole",
 					"Arn"]
 				},
-				"Runtime": "nodejs8.10",
+				"Runtime": "nodejs10.x",
 				"Timeout": 300
 			},
 			"DependsOn": ["TeleoptiIntegrationTestRole"]
@@ -286,7 +286,7 @@
 					"Fn::GetAtt": ["TeleoptiLambdaRole",
 					"Arn"]
 				},
-				"Runtime": "nodejs8.10",
+				"Runtime": "nodejs10.x",
 				"Timeout": 300
 			},
 			"DependsOn": ["TeleoptiLambdaRole"]


### PR DESCRIPTION
CloudFormation templates in connect-integration-teleopti-wfm have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.