### PR TITLE
Updated sendResponse function, removed unneeded FunctionName property…

### DIFF
--- a/templates/connect-integration-teleopti-wfm-workload.json
+++ b/templates/connect-integration-teleopti-wfm-workload.json
@@ -274,9 +274,6 @@
                         "Fn::Sub": "${QSS3KeyPrefix}functions/packages/integration/lambda.zip"
                     }
                 },
-                "FunctionName": {
-                    "Ref": "AWS::StackName"
-                },
                 "Description": "Used sync files between S3 and SFTP servers.",
                 "Environment": {
                     "Variables": {
@@ -390,9 +387,7 @@
                         "Fn::GetAtt": ["TeleoptiIntegrationFunction",
                         "Arn"]
                     },
-                    "Id": {
-                            "Ref": "AWS::StackName"
-                    }
+                    "Id": { "Fn::Select" : [ "2", { "Fn::Split" : [ "/", {"Ref":  "AWS::StackId"}] } ] }
                 }]
             }
         },


### PR DESCRIPTION
… and shortened target id for TeleoptiExecuteEvent

*Issue #, if available:*
Fixed https://github.com/aws-quickstart/connect-integration-teleopti-wfm/issues/15

*Description of changes:*
* Updated the sendResponse method to send signal to CloudFormation.
* Minor changes in the workload template to make sure it works with our testing framework. * 
  * FunctionName in TeleoptiIntegrationFunction isn't mandatory and was too long. 
  * Same thing with ID field in TeleoptiExecuteEvent. Shortened it to less than 64 characters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
