### PR TITLE
Place Lambda functions inside VPC

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -29,5 +29,7 @@ tests:
       SFTPHostname: override.example.com
       SFTPPassword: Overr1d3
       SFTPUserName: override
+      SecurityGroupIds: sg-override
+      SubnetIds: subnet-override
     s3_bucket: ''
     template: templates/connect-integration-teleopti-wfm.json

--- a/templates/connect-integration-teleopti-wfm-workload.json
+++ b/templates/connect-integration-teleopti-wfm-workload.json
@@ -7,11 +7,21 @@
                 "Label": {
                     "default": "Teleopti SFTP Credentials"
                 },
-                "Parameters": ["SFTPHostname",
-                "SFTPUserName",
-                "SFTPPassword"]
+                "Parameters": [
+                    "SecurityGroupIds",
+                    "SubnetIds",
+                    "SFTPHostname",
+                    "SFTPUserName",
+                    "SFTPPassword"
+                ]
             }],
             "ParameterLabels": {
+                "SecurityGroupIds": {
+                    "default": "List of security group IDs"
+                },
+                "SubnetIds": {
+                    "default": "List of subnet IDs"
+                },
                 "SFTPUserName": {
                     "default": "Teleopti SFTP User ID:"
                 },
@@ -41,6 +51,14 @@
         "SFTPHostname": {
             "Type": "String",
             "Description": "The Teleopti provided hostname of your SFTP server."
+        },
+        "SecurityGroupIds": {
+            "Description": "List of security group IDs in the VPC that should be attached to the Connect integration Lambda functions.",
+            "Type": "List<AWS::EC2::SecurityGroup::Id>"
+        },
+        "SubnetIds": {
+            "Description": "List of subnet IDs in the VPC that should be attached to the Connect integration Lambda functions. Note: the route table associated with the subnet(s) must point to NAT Gateway for 0.0.0.0/0 destination, and the NAT Gateway must have an elastic IP address that has been whitelisted by Calabrio.",
+            "Type": "List<AWS::EC2::Subnet::Id>"
         },
         "QSS3BucketName": {
             "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
@@ -150,6 +168,21 @@
                         "Action": ["sts:AssumeRole"]
                     }]
                 },
+				"Policies": [{
+					"PolicyName": "DBSNetworkInterface",
+					"PolicyDocument": {
+						"Version": "2012-10-17",
+						"Statement": [{
+							"Effect": "Allow",
+							"Action": [
+							"ec2:DescribeNetworkInterfaces",
+							"ec2:CreateNetworkInterface",
+							"ec2:DeleteNetworkInterface",
+							"ec2:AttachNetworkInterface"],
+							"Resource": "*"
+						}]
+					}
+				}],
                 "Path": "/",
                 "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
             }
@@ -172,6 +205,14 @@
                     "Arn"]
                 },
                 "Runtime": "nodejs10.x",
+                "VpcConfig" : {
+                    "SecurityGroupIds": {
+                        "Ref": "SecurityGroupIds"
+                    },
+                    "SubnetIds": {
+                        "Ref": "SubnetIds"
+                    }
+                  },
                 "Timeout": 300
             },
             "DependsOn": ["TeleoptiIntegrationTestRole"]
@@ -231,6 +272,21 @@
                         }]
                     }
                 },
+                {
+					"PolicyName": "DBSNetworkInterface",
+					"PolicyDocument": {
+						"Version": "2012-10-17",
+						"Statement": [{
+							"Effect": "Allow",
+							"Action": [
+							"ec2:DescribeNetworkInterfaces",
+							"ec2:CreateNetworkInterface",
+							"ec2:DeleteNetworkInterface",
+							"ec2:AttachNetworkInterface"],
+							"Resource": "*"
+						}]
+					}
+				},
                 {
                     "PolicyName": "FileSyncher",
                     "PolicyDocument": {
@@ -319,6 +375,14 @@
                     "Arn"]
                 },
                 "Runtime": "nodejs10.x",
+                "VpcConfig" : {
+                    "SecurityGroupIds": {
+                        "Ref": "SecurityGroupIds"
+                    },
+                    "SubnetIds": {
+                        "Ref": "SubnetIds"
+                    }
+                },
                 "Timeout": 300
             },
             "DependsOn": ["TeleoptiLambdaRole"]

--- a/templates/connect-integration-teleopti-wfm.json
+++ b/templates/connect-integration-teleopti-wfm.json
@@ -9,6 +9,8 @@
                         "default": "Teleopti SFTP Credentials"
                     },
                     "Parameters": [
+                        "SecurityGroupIds",
+                        "SubnetIds",
                         "SFTPHostname",
                         "SFTPUserName",
                         "SFTPPassword"
@@ -26,6 +28,12 @@
                 }
             ],
             "ParameterLabels": {
+                "SecurityGroupIds": {
+                    "default": "List of security group IDs"
+                },
+                "SubnetIds": {
+                    "default": "List of subnet IDs"
+                },
                 "SFTPUserName": {
                     "default": "Teleopti SFTP User ID:"
                 },
@@ -64,6 +72,14 @@
         "SFTPHostname": {
             "Type": "String",
             "Description": "The Teleopti provided hostname of your SFTP server."
+        },
+        "SecurityGroupIds": {
+            "Description": "List of security group IDs in the VPC that should be attached to the Connect integration Lambda functions.",
+            "Type": "List<AWS::EC2::SecurityGroup::Id>"
+        },
+        "SubnetIds": {
+            "Description": "List of subnet IDs in the VPC that should be attached to the Connect integration Lambda functions. Note: the route table associated with the subnet(s) must point to NAT Gateway for 0.0.0.0/0 destination, and the NAT Gateway must have an elastic IP address that has been whitelisted by Calabrio.",
+            "Type": "List<AWS::EC2::Subnet::Id>"
         },
         "QSS3BucketName": {
             "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
@@ -192,6 +208,22 @@
                     },
                     "SFTPPassword": {
                         "Ref": "SFTPPassword"
+                    },
+                    "SecurityGroupIds": {
+                        "Fn::Join": [
+                            ",",
+                            {
+                                "Ref": "SecurityGroupIds"
+                            }
+                        ]
+                    },
+                    "SubnetIds": {
+                        "Fn::Join": [
+                            ",",
+                            {
+                                "Ref": "SubnetIds"
+                            }
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
Placed Lambda functions in a VPC. Added subnet ID and security group of the VPC as inputs. The Lambda function should be placed in a private subnet which has a route out to the internet through a NAT gateway. The NAT gateway must have an elastic IP address that has been whitelisted by Calabrio.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
